### PR TITLE
Tweak dependencies and testcases

### DIFF
--- a/fluent-plugin-nsq.gemspec
+++ b/fluent-plugin-nsq.gemspec
@@ -17,7 +17,11 @@ Gem::Specification.new do |s|
   s.test_files    = git_files.grep(%r{^(test|spec|features)/})
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency 'fluentd', '~> 0.10'
-  s.add_runtime_dependency 'nsq-ruby', '~> 1.0'
+  s.add_runtime_dependency 'fluentd', ['>= 0.12.0', '< 2']
+  s.add_runtime_dependency 'nsq-ruby', '~> 2.1'
+  s.add_development_dependency 'nsq-cluster', '~> 2.1'
+  s.add_development_dependency 'test-unit', '~> 3.2'
+  s.add_development_dependency 'minitest', '~> 5.10'
   s.add_development_dependency 'rake', '~> 10'
+  s.add_development_dependency 'bundler', '~> 1.13'
 end

--- a/lib/fluent/plugin/in_nsq.rb
+++ b/lib/fluent/plugin/in_nsq.rb
@@ -5,6 +5,11 @@ module Fluent
   class NSQInput < Input
     Plugin.register_input('nsq', self)
 
+    # Define `router` method of v0.12 to support v0.10 or earlier
+    unless method_defined?(:router)
+      define_method("router") { Fluent::Engine }
+    end
+
     config_param :topic, :string, default: nil
     config_param :channel, :string, default: 'fluent_nsq_input'
     config_param :in_flight, :integer, default: 100
@@ -71,7 +76,7 @@ module Fluent
       record = Yajl.load(msg.body.force_encoding('UTF-8'))
       record_tag = tag_for_record(record)
       record_time = time_for_record(record, msg)
-      Engine.emit(record_tag, record_time, record)
+      router.emit(record_tag, record_time, record)
       msg.finish
     rescue => e
       log.warn("nsq: #{e}")

--- a/lib/fluent/plugin/in_nsq.rb
+++ b/lib/fluent/plugin/in_nsq.rb
@@ -59,9 +59,9 @@ module Fluent
     end
 
     def shutdown
-      super
       @running = false
       @consumer.terminate
+      super
     end
 
     private

--- a/lib/fluent/plugin/in_nsq.rb
+++ b/lib/fluent/plugin/in_nsq.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+require 'fluent/input'
 
 module Fluent
   class NSQInput < Input

--- a/lib/fluent/plugin/out_nsq.rb
+++ b/lib/fluent/plugin/out_nsq.rb
@@ -30,8 +30,8 @@ module Fluent
     end
 
     def shutdown
-      super
       @producer.terminate
+      super
     end
 
     def format(tag, time, record)

--- a/test/plugin/test_in_nsq.rb
+++ b/test/plugin/test_in_nsq.rb
@@ -58,7 +58,12 @@ class TestNSQInput < Test::Unit::TestCase
     d = create_driver
     d.run do
       prod = create_producer
-      sleep(1)
+      connected = false
+      while(!connected) do
+        connected = prod.connected?
+        break if connected
+        sleep(1)
+      end
       prod.write(sample_record.to_json)
       prod.write(sample_record.to_json)
       prod.write(sample_record.to_json)


### PR DESCRIPTION
Hi, I've found that this plugin has some problem to use with Fluentd v0.14 compat layer.
Fluentd v0.10 is already EOL.
Its plugins should depend on v0.12 or later.

Perhaps, this PR contains a bit of big changes.
Could you review this PR?

I hope that this plugin will work with v0.14 compat layer.

Thanks, 