### PR TITLE
Upgrade the version of ruby-nsq to be compatible with NSQ v1.0

### DIFF
--- a/fluent-plugin-nsq.gemspec
+++ b/fluent-plugin-nsq.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency 'fluentd', '~> 0.10'
-  s.add_runtime_dependency 'nsq-ruby', '~> 1.0'
+  s.add_runtime_dependency 'nsq-ruby', '~> 2.1'
   s.add_development_dependency 'rake', '~> 10'
 end


### PR DESCRIPTION
### Problem

The ruby client (ruby-nsq) prior to v2.1 only supports the pre-V1 HTTP endpoint of nsqlookupd.

Since fluent-plugin-nsq is relying on an old v1.X client, the plugin is incompatible with the latest
NSQ versions right now. This is the root cause of the issue reported by the ticket #3.

### Solution

This patch fixes the issue by upgrading the version of the ruby client.

With this patch applied, the plugin was confirmed to work fine with both NSQ v1.0 and v0.38.