### PR TITLE
Prevent Fluentd from upgrading to v0.14

### DIFF
--- a/fluent-plugin-nsq.gemspec
+++ b/fluent-plugin-nsq.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files    = git_files.grep(%r{^(test|spec|features)/})
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency 'fluentd', '~> 0.10'
+  s.add_runtime_dependency 'fluentd', ['~> 0.10', '< 0.14']
   s.add_runtime_dependency 'nsq-ruby', '~> 2.1'
   s.add_development_dependency 'rake', '~> 10'
 end


### PR DESCRIPTION
Because the current plugin relies on the old Fluentd API which has
been deprecated since v0.14, it cannot be used with Fluentd v0.14
or later.

This patch clarifies this point by adding '< 0.14' to the version specifier
in the gemspec file. This should prevent Fluentd from upgrading to the
incompatible versions accidentally.