### PR TITLE
Add test-unit v3 to the dependancy list for Ruby 2.4

### DIFF
--- a/fluent-plugin-nsq.gemspec
+++ b/fluent-plugin-nsq.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'fluentd', ['~> 0.10', '< 0.14']
   s.add_runtime_dependency 'nsq-ruby', '~> 2.1'
   s.add_development_dependency 'rake', '~> 10'
+  s.add_development_dependency("test-unit", ["~> 3.2"])
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,1 +1,0 @@
-require 'minitest/pride'


### PR DESCRIPTION
This patch adds `test-unit` v3 to the dependancy list for Ruby 2.4.
It also removes minitest/pride from the dependancy since it is not
available anymore.

I confirmed the test passes successfully using Fluentd v0.12.43
running on Ruby 2.4.3.

Note: I specified the gemfile to use test-unit 3.2 or later since Fluentd
v0.12 uses these versions of the `test-unit` gem right now.