### PR TITLE
Migrate the input/output plugins to Fluentd v1 API

### DIFF
--- a/fluent-plugin-nsq.gemspec
+++ b/fluent-plugin-nsq.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files    = git_files.grep(%r{^(test|spec|features)/})
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency 'fluentd', ['~> 0.10', '< 0.14']
+  s.add_runtime_dependency 'fluentd', ['> 0.14', '< 2']
   s.add_runtime_dependency 'nsq-ruby', '~> 2.1'
   s.add_development_dependency 'rake', '~> 10'
   s.add_development_dependency("test-unit", ["~> 3.2"])

--- a/fluent-plugin-nsq.gemspec
+++ b/fluent-plugin-nsq.gemspec
@@ -20,5 +20,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'fluentd', ['> 0.14', '< 2']
   s.add_runtime_dependency 'nsq-ruby', '~> 2.1'
   s.add_development_dependency 'rake', '~> 10'
+  s.add_development_dependency 'json', '~> 2'
   s.add_development_dependency("test-unit", ["~> 3.2"])
 end

--- a/lib/fluent/plugin/in_nsq.rb
+++ b/lib/fluent/plugin/in_nsq.rb
@@ -11,7 +11,7 @@ module Fluent::Plugin
     config_param :topic, :string, default: nil
     config_param :channel, :string, default: 'fluent_nsq_input'
     config_param :in_flight, :integer, default: 100
-    config_param :nsqlookupd, :string, default: nil
+    config_param :nsqlookupd, :array, default: nil
     config_param :tag, :string, default: '_key'
     config_param :time_key, :string, default: nil
     config_param :tag_source, default: :key do |val|
@@ -38,9 +38,8 @@ module Fluent::Plugin
 
     def start
       super
-      lookupds = @nsqlookupd.split(',')
       @consumer = Nsq::Consumer.new(
-        nsqlookupd: lookupds,
+        nsqlookupd: @nsqlookupd,
         topic: @topic,
         channel: @channel,
         max_in_flight: @in_flight

--- a/lib/fluent/plugin/in_nsq.rb
+++ b/lib/fluent/plugin/in_nsq.rb
@@ -88,7 +88,7 @@ module Fluent::Plugin
       if @time_key
         record[@time_key]
       else
-        msg.timestamp.to_i
+        Fluent::EventTime.new(msg.timestamp.to_i, msg.timestamp.nsec)
       end
     end
   end

--- a/lib/fluent/plugin/out_nsq.rb
+++ b/lib/fluent/plugin/out_nsq.rb
@@ -9,7 +9,7 @@ module Fluent::Plugin
     Fluent::Plugin.register_output('nsq', self)
 
     config_param :topic, :string, default: nil
-    config_param :nsqlookupd, :string, default: nil
+    config_param :nsqlookupd, :array, default: nil
 
     config_section :buffer do
       config_set_default :chunk_keys, ['tag']
@@ -24,9 +24,8 @@ module Fluent::Plugin
 
     def start
       super
-      lookupds = @nsqlookupd.split(',')
       @producer = Nsq::Producer.new(
-        nsqlookupd: lookupds,
+        nsqlookupd: @nsqlookupd,
         topic: @topic
       )
     end

--- a/lib/fluent/plugin/out_nsq.rb
+++ b/lib/fluent/plugin/out_nsq.rb
@@ -42,8 +42,8 @@ module Fluent::Plugin
       chunk.each do |time, record|
         tagged_record = record.merge(
           :_key => tag,
-          :_ts => time,
-          :'@timestamp' => Time.at(time).to_datetime.to_s  # kibana/elasticsearch friendly
+          :_ts => time.to_f,
+          :'@timestamp' => Time.at(time).iso8601(3) # kibana/elasticsearch friendly
         )
         begin
           @producer.write(Yajl.dump(tagged_record))

--- a/lib/fluent/plugin/out_nsq.rb
+++ b/lib/fluent/plugin/out_nsq.rb
@@ -1,23 +1,25 @@
 # coding: utf-8
 
-module Fluent
-  class NSQOutput < BufferedOutput
-    Plugin.register_output('nsq', self)
+require 'fluent/plugin/output'
+require 'nsq'
+require 'yajl'
+
+module Fluent::Plugin
+  class NSQOutput < Output
+    Fluent::Plugin.register_output('nsq', self)
 
     config_param :topic, :string, default: nil
     config_param :nsqlookupd, :string, default: nil
 
-    def initialize
-      super
-      require 'nsq'
-      require 'yajl'
+    config_section :buffer do
+      config_set_default :chunk_keys, ['tag']
     end
 
     def configure(conf)
       super
 
-      fail ConfigError, 'Missing nsqlookupd' unless @nsqlookupd
-      fail ConfigError, 'Missing topic' unless @topic
+      fail Fluent::ConfigError, 'Missing nsqlookupd' unless @nsqlookupd
+      fail Fluent::ConfigError, 'Missing topic' unless @topic
     end
 
     def start
@@ -30,20 +32,15 @@ module Fluent
     end
 
     def shutdown
-      super
       @producer.terminate
-    end
-
-    def format(tag, time, record)
-      [tag, time, record].to_msgpack
+      super
     end
 
     def write(chunk)
       return if chunk.empty?
 
-      chunk.msgpack_each do |tag, time, record|
-        next unless record.is_a? Hash
-        # TODO get rid of this extra copy
+      tag = chunk.metadata.tag
+      chunk.each do |time, record|
         tagged_record = record.merge(
           :_key => tag,
           :_ts => time,

--- a/test/plugin/test_in_nsq.rb
+++ b/test/plugin/test_in_nsq.rb
@@ -1,6 +1,7 @@
 require 'test/unit'
 
 require 'fluent/test'
+require 'fluent/test/driver/input'
 require 'fluent/plugin/in_nsq'
 
 require 'date'
@@ -27,7 +28,7 @@ class TestNSQInput < Test::Unit::TestCase
   end
 
   def create_driver(conf=TCONFIG)
-    Fluent::Test::InputTestDriver.new(Fluent::NSQInput).configure(conf)
+    Fluent::Test::Driver::Input.new(Fluent::Plugin::NSQInput).configure(conf)
   end
 
   def create_producer
@@ -60,6 +61,6 @@ class TestNSQInput < Test::Unit::TestCase
       prod.terminate
     end
     puts("emitz")
-    puts(d.emits)
+    puts(d.events)
   end
 end

--- a/test/plugin/test_out_nsq.rb
+++ b/test/plugin/test_out_nsq.rb
@@ -1,6 +1,7 @@
 require 'test/unit'
 
 require 'fluent/test'
+require 'fluent/test/driver/output'
 require 'fluent/plugin/out_nsq'
 
 require 'date'
@@ -25,8 +26,8 @@ class TestNSQOutput < Test::Unit::TestCase
     assert_not_nil d.instance.topic
   end
 
-  def create_driver(tag='test', conf=TCONFIG)
-    Fluent::Test::BufferedOutputTestDriver.new(Fluent::NSQOutput, tag).configure(conf, true)
+  def create_driver(conf=TCONFIG)
+    Fluent::Test::Driver::Output.new(Fluent::Plugin::NSQOutput).configure(conf)
   end
 
   def sample_record
@@ -35,15 +36,16 @@ class TestNSQOutput < Test::Unit::TestCase
 
   def test_wrong_config
     assert_raise Fluent::ConfigError do
-      create_driver('test','')
+      create_driver('')
     end
   end
 
   def test_sample_record_loop
     d = create_driver
-    100.times.each do |t|
-      d.emit(sample_record)
+    d.run(default_tag: 'test') do
+      100.times.each do |t|
+        d.feed(sample_record)
+      end
     end
-    d.run
   end
 end


### PR DESCRIPTION
### What's this patch?

This commit upgrades both `in_nsq` and `out_nsq` to use the latest plugin
API of Fluentd.

The test suite is also updated to be compatible with Fluentd v1.0

### Note
    
* This patch effectively makes the plugin incompatible with Fluentd v0.12;
* Hereafter, only Fluentd v0.14 or later is supported.
