### PR TITLE
Update ruby-nsq to 2.3

### DIFF
--- a/fluent-plugin-nsq.gemspec
+++ b/fluent-plugin-nsq.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency 'fluentd', ['> 0.14', '< 2']
-  s.add_runtime_dependency 'nsq-ruby', '~> 2.1'
+  s.add_runtime_dependency 'nsq-ruby', '~> 2.3'
   s.add_development_dependency 'rake', '~> 10'
   s.add_development_dependency 'json', '~> 2'
   s.add_development_dependency("test-unit", ["~> 3.2"])


### PR DESCRIPTION
It seems like this plugin does not work with nsqlookupd of v 1.1 - it looks just as reported in #3. I updated ruby-nsq to the latest version (2.3) and it works just fine.